### PR TITLE
🥡 feat: add refs overwriting

### DIFF
--- a/src/pages/example/$refs-overwriting.vue
+++ b/src/pages/example/$refs-overwriting.vue
@@ -1,0 +1,60 @@
+<template lang="pug">
+div
+  h1.title
+    | $refs-overwriting
+  p
+    input(
+      type="text"
+      placeholder="カフェ"
+      ref="suggestInput"
+    )
+  p
+    input(
+      type="checkbox"
+      ref="suggestCheck"
+      value="1"
+    )
+    | 居酒屋
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+
+@Component
+export default class RefsOverwiting extends Vue {
+  $refs!: {
+    suggestInput: HTMLElement
+    suggestCheck: HTMLFormElement
+  }
+
+  mounted() {
+    console.log('mounted')
+
+    // via add example of $ref casting to any in documentation · Issue #94 · vuejs/vue-class-component - https://github.com/vuejs/vue-class-component/issues/94
+
+    // HTMLElement に as でキャストするパターン
+    // const suggestInput: HTMLElement = this.$refs.suggestInput as HTMLElement
+    // suggestInput.focus()
+    // const suggestCheck: HTMLFormElement = this.$refs.suggestCheck as HTMLFormElement
+    // suggestCheck.checked = true
+
+    // or
+
+    // $refs を再定義して、事前に型を定義しておくパターン
+    this.$refs.suggestInput.focus()
+    this.$refs.suggestCheck.checked = true
+  }
+
+  public head() {
+    return {
+      title: '$refs-overwriting'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.color {
+  @extend .color;
+}
+</style>

--- a/src/pages/example/index.vue
+++ b/src/pages/example/index.vue
@@ -78,6 +78,8 @@ section
   p
     nuxt-link(to='/example/get-domain-in-head', no-prefetch) get-domain-in-head
   p
+    nuxt-link(to='/example/$refs-overwriting', no-prefetch) $refs-overwriting
+  p
     a(href='/static-html') static html
 </template>
 


### PR DESCRIPTION
## 変更内容

[add example of $ref casting to any in documentation · Issue #94 · vuejs/vue-class-component](https://github.com/vuejs/vue-class-component/issues/94)

* HTML 要素のメンバにアクセスするために HTMLFormElement 型に as キャストしないと動かないかどうか
* $refs を再定義することで、キャストを一箇所にまとめられる

結果的に as キャストしてもいいし、 $refs の再定義してもいいという結論になった。