### PR TITLE
Feature/add refs overwriting for calling childmethod

### DIFF
--- a/src/components/pages/Example/ParentComponent.vue
+++ b/src/components/pages/Example/ParentComponent.vue
@@ -17,6 +17,10 @@ import ChildComponent from '@/components/pages/Example/ChildComponent.vue'
   }
 })
 export default class ParentComponent extends Vue {
+  public parentMethod() {
+    console.log('parentMethod')
+  }
+
   @Emit('parent-click')
   public handleParentClick(counter, e) {
     return counter

--- a/src/pages/example/nested-component.vue
+++ b/src/pages/example/nested-component.vue
@@ -4,6 +4,7 @@ section.container
     | nested-component
   ParentComponent(
     @parent-click="handleRootClick"
+    ref="parentComponent"
   )
 </template>
 
@@ -16,7 +17,16 @@ import ParentComponent from '@/components/pages/Example/ParentComponent.vue'
     ParentComponent
   }
 })
-export default class extends Vue {
+export default class NestedComponent extends Vue {
+  // add example of $ref casting to any in documentation · Issue #94 · vuejs/vue-class-component - https://github.com/vuejs/vue-class-component/issues/94
+  $refs!: {
+    parentComponent: HTMLFormElement
+  }
+
+  public mounted() {
+    this.$refs.parentComponent.parentMethod()
+  }
+
   public handleRootClick(counter, e) {
     console.log('handleRootClick', counter)
   }


### PR DESCRIPTION
## 変更内容

[add example of $ref casting to any in documentation · Issue #94 · vuejs/vue-class-component](https://github.com/vuejs/vue-class-component/issues/94)

* input 要素ではなく、親から子のメソッドを呼ぶときに ts エラーが出るのを $refs で回避する方法
