### PR TITLE
IE11でsyntax error出ないように修正

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,6 +42,9 @@ const config: NuxtConfiguration = {
     // https://ja.nuxtjs.org/api/configuration-build/#devtools
     devtools: true,
 
+    transpile: [
+      'is-https',
+    ],
     loaders: {
       // https://ja.nuxtjs.org/faq/webpack-audio-files/
       vue: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,10 +42,11 @@ const config: NuxtConfiguration = {
     // https://ja.nuxtjs.org/api/configuration-build/#devtools
     devtools: true,
 
+    // 特定の依存関係を Babel で変換したい場合、マッチする依存ファイル名の文字列または正規表現オブジェクトをここに書く
     transpile: [
-      'is-https',
       'is-https'
     ],
+
     loaders: {
       // https://ja.nuxtjs.org/faq/webpack-audio-files/
       vue: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,9 +42,6 @@ const config: NuxtConfiguration = {
     // https://ja.nuxtjs.org/api/configuration-build/#devtools
     devtools: true,
 
-    // 特定の依存関係を Babel で変換したい場合、マッチする依存ファイル名の文字列または正規表現オブジェクトをここに書く
-    transpile: ['is-https'],
-
     loaders: {
       // https://ja.nuxtjs.org/faq/webpack-audio-files/
       vue: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,9 +43,7 @@ const config: NuxtConfiguration = {
     devtools: true,
 
     // 特定の依存関係を Babel で変換したい場合、マッチする依存ファイル名の文字列または正規表現オブジェクトをここに書く
-    transpile: [
-      'is-https'
-    ],
+    transpile: ['is-https'],
 
     loaders: {
       // https://ja.nuxtjs.org/faq/webpack-audio-files/

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,6 +44,7 @@ const config: NuxtConfiguration = {
 
     transpile: [
       'is-https',
+      'is-https'
     ],
     loaders: {
       // https://ja.nuxtjs.org/faq/webpack-audio-files/

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "cookie-parser": "^1.4.4",
     "cross-env": "^5.2.1",
     "express": "^4.17.1",
-    "is-https": "^1.0.0",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",

--- a/src/utilities/getHost.ts
+++ b/src/utilities/getHost.ts
@@ -5,7 +5,7 @@
  *
  * @param {req} request
  */
-import isHTTPS from 'is-https'
+import isHTTPS from './is-https'
 
 export function getHost(req: any, domain?: string): string {
   let host = ''

--- a/src/utilities/is-https.ts
+++ b/src/utilities/is-https.ts
@@ -1,0 +1,50 @@
+/**
+ * is-https
+ *
+ * is-https/index.js at master · nuxt-community/is-https - https://github.com/nuxt-community/is-https/blob/master/index.js#L1
+ * `xForwardedProto = true` のデフォルト引数の箇所が IE11 でエラーが出るためローカルにコピー
+ *
+ * @see nuxt-community/is-https: Check if the given request is HTTPS - https://github.com/nuxt-community/is-https
+ *
+ * @param {req} request
+ * @param {xForwardedProto}
+ */
+function isEmpty(v) {
+  return v === undefined || v === null
+}
+
+export default function isHTTPS(req, xForwardedProto = true) {
+  // Test using req.connection.encrypted
+  const encrypted = isEmpty(req.connection.encrypted)
+    ? null
+    : req.connection.encrypted === true
+  if (encrypted) {
+    return true
+  }
+
+  // Test using req.protocol
+  const httpsProtocol = isEmpty(req.protocol) ? null : req.protocol === 'https'
+  if (httpsProtocol) {
+    return true
+  }
+
+  // Test using x-forwarded-proto header
+  const httpsXforwarded =
+    !xForwardedProto || isEmpty(req.headers['x-forwarded-proto'])
+      ? null
+      : req.headers['x-forwarded-proto'].includes('https')
+  if (httpsXforwarded) {
+    return true
+  }
+
+  // If no detection method is available return null
+  if (
+    encrypted === null &&
+    httpsProtocol === null &&
+    httpsXforwarded === null
+  ) {
+    return null
+  }
+
+  return false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8008,11 +8008,6 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
   integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
 
-is-https@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-https/-/is-https-1.0.0.tgz#9c1dde000dc7e7288edb983bef379e498e7cb1bf"
-  integrity sha512-1adLLwZT9XEXjzhQhZxd75uxf0l+xI9uTSFaZeSESjL3E1eXSPpO+u5RcgqtzeZ1KCaNvtEwZSTO2P4U5erVqQ==
-
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"


### PR DESCRIPTION
## 変更内容

`is-https` というモジュールをnode_modulesから削除し、

`src` ディレクトリ下に配置して Typescript コンパイラを通るようにした

## 変更理由

`is-https` というモジュールの中で使われているデフォルト引数が原因で、IE11でsyntax errorが発生していた


## 共有事項・補足

<!-- レビューにおける共有事項、保留中の処理、気になること、など記載 -->

公式ドキュメント
https://ja.nuxtjs.org/api/configuration-build/#transpile
